### PR TITLE
Reproduce https://github.com/tonybaloney/pycharm-security/issues/33

### DIFF
--- a/src/main/java/security/packaging/PyPackageSecurityScan.kt
+++ b/src/main/java/security/packaging/PyPackageSecurityScan.kt
@@ -76,15 +76,15 @@ object PyPackageSecurityScan {
         }
     }
 
-    private fun renderMessage(issue: SafetyDbChecker.SafetyDbRecord) : String{
-        return if (issue.cve.isEmpty()){
+    fun renderMessage(issue: SafetyDbChecker.SafetyDbRecord) : String {
+        return if (issue.cve.isNullOrEmpty()){
             issue.advisory
         } else {
             "${issue.advisory}<br>See <a href='https://cve.mitre.org/cgi-bin/cvename.cgi?name=${issue.cve}'>${issue.cve}</a>"
         }
     }
 
-    private fun getPythonSdks(project: Project): Set<Sdk> {
+    fun getPythonSdks(project: Project): Set<Sdk> {
         val pythonSdks: MutableSet<Sdk> = Sets.newLinkedHashSet()
         for (module in ModuleManager.getInstance(project).modules) {
             val sdk = PythonSdkUtil.findPythonSdk(module)

--- a/src/main/java/security/packaging/SafetyDbChecker.kt
+++ b/src/main/java/security/packaging/SafetyDbChecker.kt
@@ -18,7 +18,7 @@ class SafetyDbChecker {
 
     data class SafetyDbRecord(
         val advisory: String,
-        val cve: String,
+        val cve: String?,
         val id: String,
         val specs: List<String>,
         val v: String

--- a/src/test/java/security/packaging/PyPackageSecurityScanTest.kt
+++ b/src/test/java/security/packaging/PyPackageSecurityScanTest.kt
@@ -36,4 +36,18 @@ class PyPackageSecurityScanTest: SecurityTestTask() {
         verify(mockNotificationGroup, times(1)).createNotification( eq("Could not check Python packages"), anyOrNull<String>(), any<String>(), eq(NotificationType.INFORMATION))
         verify(mockNotification, times(1)).notify(project)
     }
+
+    @Test
+    fun `test render renderMessage with null cve record`(){
+        val record = SafetyDbChecker.SafetyDbRecord("Test is bad", null, "xyz", listOf("<= 1.0.0"), "<= 1.0.0")
+        val message = PyPackageSecurityScan.renderMessage(record)
+        assertFalse(message.isEmpty())
+    }
+
+    @Test
+    fun `test render renderMessage with valid cve record`(){
+        val record = SafetyDbChecker.SafetyDbRecord("Test is bad", "CVE-2020-123.3", "xyz", listOf("<= 1.0.0"), "<= 1.0.0")
+        val message = PyPackageSecurityScan.renderMessage(record)
+        assertFalse(message.isEmpty())
+    }
 }


### PR DESCRIPTION
Issue:
 - Even though SafetyDbRecord declares cve field as non-nullable, deserializer writes nullable values
 - Nullable values exist in the database
 - When message is rendered for a nullable CVE entry, call to issue.cve.isEmpty() will return a NPE

 Fix:
 - Update model so cve is a nullable string
 - Update renderMessage so isNullOrEmpty is used
 - Test both scenarios