### PR TITLE
Prevent GitHub action failing when no warnings

### DIFF
--- a/.github/actions/action.sh
+++ b/.github/actions/action.sh
@@ -5,7 +5,7 @@ echo "Scanning $1 with profile $2"
 
 set -e
 HASWARNINGS=0
-for i in out/*.json; do
+for i in $(find out -name "*.json"); do
     RUNHASWARNINGS=0
     cat $i | python3 /code/parse.py || RUNHASWARNINGS=$?
     if [ $RUNHASWARNINGS -ne 0 ]; then
@@ -18,4 +18,6 @@ if [ $HASWARNINGS -ne 0 ]; then
     echo "Found issues in code"
     exit 1
   fi
+else
+  echo "Found no issues in the code"
 fi


### PR DESCRIPTION
Use find to get list of JSON files to prevent the following error (Fixes: #70).

```bash
Run tonybaloney/pycharm-security@1.8.0
<deleted-doccker-command>
Scanning src/ with profile /sources/SecurityInspectionProfile.xml
cat: 'out/*.json': No such file or directory
Traceback (most recent call last):
  File "/code/parse.py", line 23, in <module>
    main()
  File "/code/parse.py", line 6, in main
    data = json.load(sys.stdin)
  File "/usr/lib/python3.6/json/__init__.py", line 299, in load
    parse_constant=parse_constant, object_pairs_hook=object_pairs_hook, **kw)
  File "/usr/lib/python3.6/json/__init__.py", line 354, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.6/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.6/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
Found issues in code
##[error]Docker run failed with exit code 1
```