### PR TITLE
Run CI/CD against PyCharm 2019.3 and 2020.1 EAP

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,23 +13,14 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 11
-    - name: Build PC-2019.3.3
-      uses: eskatos/gradle-command-action@v1
-      with:
-        arguments: build -PintellijPublishToken=FAKE_TOKEN -PintellijVersion=PC-2019.3.3
     - name: Test PC-2019.3.3
       uses: eskatos/gradle-command-action@v1
       with:
         arguments: test -PintellijPublishToken=FAKE_TOKEN -PintellijVersion=PC-2019.3.3
-    - name: Build PC-201.5616-EAP-CANDIDATE-SNAPSHOT
-      uses: eskatos/gradle-command-action@v1
-      with:
-        arguments: build -PintellijPublishToken=FAKE_TOKEN -PintellijVersion=PC-201.5616-EAP-CANDIDATE-SNAPSHOT
     - name: Test 201.5616-EAP-CANDIDATE-SNAPSHOT
       uses: eskatos/gradle-command-action@v1
       with:
         arguments: test -PintellijPublishToken=FAKE_TOKEN -PintellijVersion=PC-201.5616-EAP-CANDIDATE-SNAPSHOT
-
     - uses: eskatos/gradle-command-action@v1
       with:
         arguments: jacocoTestReport -PintellijPublishToken=FAKE_TOKEN -PintellijVersion=PC-2019.3.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,15 +13,26 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 11
+    - name: Build PC-2019.3.3
+      uses: eskatos/gradle-command-action@v1
+      with:
+        arguments: build -PintellijPublishToken=FAKE_TOKEN -PintellijVersion=PC-2019.3.3
+    - name: Test PC-2019.3.3
+      uses: eskatos/gradle-command-action@v1
+      with:
+        arguments: test -PintellijPublishToken=FAKE_TOKEN -PintellijVersion=PC-2019.3.3
+    - name: Build PC-201.5616-EAP-CANDIDATE-SNAPSHOT
+      uses: eskatos/gradle-command-action@v1
+      with:
+        arguments: build -PintellijPublishToken=FAKE_TOKEN -PintellijVersion=PC-201.5616-EAP-CANDIDATE-SNAPSHOT
+    - name: Test 201.5616-EAP-CANDIDATE-SNAPSHOT
+      uses: eskatos/gradle-command-action@v1
+      with:
+        arguments: test -PintellijPublishToken=FAKE_TOKEN -PintellijVersion=PC-201.5616-EAP-CANDIDATE-SNAPSHOT
+
     - uses: eskatos/gradle-command-action@v1
       with:
-        arguments: build -PintellijPublishToken=FAKE_TOKEN -PideaPath="" --info
-    - uses: eskatos/gradle-command-action@v1
-      with:
-        arguments: test -PintellijPublishToken=FAKE_TOKEN -PideaPath="" --info
-    - uses: eskatos/gradle-command-action@v1
-      with:
-        arguments: jacocoTestReport -PintellijPublishToken=FAKE_TOKEN
+        arguments: jacocoTestReport -PintellijPublishToken=FAKE_TOKEN -PintellijVersion=PC-2019.3.3
     - name: Codecov
       uses: codecov/codecov-action@v1.0.5
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push]
 
 jobs:
-  gradle:
+  tests:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -17,9 +17,14 @@ jobs:
     - name: Test
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: test -PintellijPublishToken=FAKE_TOKEN -PintellijVersion=$VERSION
-      env:
-        VERSION: ${{ matrix.pycharm-version }}
+        arguments: test -PintellijPublishToken=FAKE_TOKEN -PintellijVersion=${{ matrix.pycharm-version }}
+  coverage:
+    runs-on: 'ubuntu-latest'
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-java@v1
+    with:
+      java-version: 11
     - uses: eskatos/gradle-command-action@v1
       with:
         arguments: jacocoTestReport -PintellijPublishToken=FAKE_TOKEN -PintellijVersion=PC-2019.3.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,9 @@ jobs:
     - name: Test
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: test -PintellijPublishToken=FAKE_TOKEN -PintellijVersion={{ matrix.pycharm-version }}
+        arguments: test -PintellijPublishToken=FAKE_TOKEN -PintellijVersion=$VERSION
+      env:
+        VERSION: ${{ matrix.pycharm-version }}
     - uses: eskatos/gradle-command-action@v1
       with:
         arguments: jacocoTestReport -PintellijPublishToken=FAKE_TOKEN -PintellijVersion=PC-2019.3.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,8 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-java@v1
-    with:
-      java-version: 11
+      with:
+        java-version: 11
     - uses: eskatos/gradle-command-action@v1
       with:
         arguments: jacocoTestReport -PintellijPublishToken=FAKE_TOKEN -PintellijVersion=PC-2019.3.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,20 +7,17 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        pycharm-version: ['PC-2019.3.3', '201.5616-EAP-CANDIDATE-SNAPSHOT']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-java@v1
       with:
         java-version: 11
-    - name: Test PC-2019.3.3
+    - name: Test
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: test -PintellijPublishToken=FAKE_TOKEN -PintellijVersion=PC-2019.3.3
-    - name: Test 201.5616-EAP-CANDIDATE-SNAPSHOT
-      uses: eskatos/gradle-command-action@v1
-      with:
-        arguments: test -PintellijPublishToken=FAKE_TOKEN -PintellijVersion=201.5616-EAP-CANDIDATE-SNAPSHOT
+        arguments: test -PintellijPublishToken=FAKE_TOKEN -PintellijVersion={{ matrix.pycharm-version }}
     - uses: eskatos/gradle-command-action@v1
       with:
         arguments: jacocoTestReport -PintellijPublishToken=FAKE_TOKEN -PintellijVersion=PC-2019.3.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Test 201.5616-EAP-CANDIDATE-SNAPSHOT
       uses: eskatos/gradle-command-action@v1
       with:
-        arguments: test -PintellijPublishToken=FAKE_TOKEN -PintellijVersion=PC-201.5616-EAP-CANDIDATE-SNAPSHOT
+        arguments: test -PintellijPublishToken=FAKE_TOKEN -PintellijVersion=201.5616-EAP-CANDIDATE-SNAPSHOT
     - uses: eskatos/gradle-command-action@v1
       with:
         arguments: jacocoTestReport -PintellijPublishToken=FAKE_TOKEN -PintellijVersion=PC-2019.3.3

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ intellij {
     updateSinceUntilBuild false
 }
 // Make the intellij version overridable on the command line to support multiple build versions..
-intellij.version = project.hasProperty('intellijVersion') ? project.getProperty('intellijVersion') : '201.5616-EAP-CANDIDATE-SNAPSHOT'
+intellij.version = project.hasProperty('intellijVersion') ? project.getProperty('intellijVersion') : '2019.3'
 
 
 patchPluginXml {

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ intellij {
     updateSinceUntilBuild false
 }
 // Make the intellij version overridable on the command line to support multiple build versions..
-intellij.version = project.hasProperty('intellijVersion') ? project.getProperty('intellijVersion') : 'PC-2019.3'
+intellij.version = project.hasProperty('intellijVersion') ? project.getProperty('intellijVersion') : '201.5616-EAP-CANDIDATE-SNAPSHOT'
 
 
 patchPluginXml {

--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ repositories {
 dependencies {
     testCompile group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.5.2'
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
-    testImplementation "net.bytebuddy:byte-buddy:1.10.5"
-    testImplementation "net.bytebuddy:byte-buddy-agent:1.10.5"
+    testImplementation "net.bytebuddy:byte-buddy:1.10.8"
+    testImplementation "net.bytebuddy:byte-buddy-agent:1.10.8"
     implementation "org.jetbrains.kotlin:kotlin-stdlib"
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -29,11 +29,13 @@ test {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version 'PC-2019.3.3'
     type 'PC'
     plugins 'python-ce', 'yaml'
     updateSinceUntilBuild false
 }
+// Make the intellij version overridable on the command line to support multiple build versions..
+intellij.version = project.hasProperty('intellijVersion') ? project.getProperty('intellijVersion') : 'PC-2019.3'
+
 
 patchPluginXml {
     changeNotes """

--- a/src/test/java/security/packaging/PyPackageSecurityScanTest.kt
+++ b/src/test/java/security/packaging/PyPackageSecurityScanTest.kt
@@ -1,12 +1,12 @@
 package security.packaging
 
-import com.intellij.notification.Notification
-import com.intellij.notification.NotificationGroup
-import com.intellij.notification.NotificationType
 import com.intellij.openapi.projectRoots.Sdk
 import com.jetbrains.python.packaging.PyPackage
 import com.jetbrains.python.packaging.PyPackageManager
-import com.nhaarman.mockitokotlin2.*
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -69,78 +69,36 @@ class PyPackageSecurityScanTest: SecurityTestTask() {
 
     @Test
     fun `test no python sdk raises info message`(){
-        val mockNotification = mock<Notification> {
-            on { notify(any()) } doAnswer {}
-        }
-        val mockNotificationGroup = mock<NotificationGroup> {
-            on { createNotification( any(), anyOrNull(), any(), any<NotificationType>(), anyOrNull())} doReturn(mockNotification)
-        }
-        PyPackageSecurityScan.NOTIFICATION_GROUP = mockNotificationGroup
-        PyPackageSecurityScan.checkPackages(project)
-        verify(mockNotificationGroup, times(1)).createNotification( eq("Could not check Python packages"), anyOrNull(), any(), eq(NotificationType.INFORMATION), anyOrNull())
-        verify(mockNotification, times(1)).notify(project)
+        assertNull(PyPackageSecurityScan.checkPackages(project))
     }
 
     @Test
     fun `test check packages`(){
-        val mockNotification = mock<Notification> {
-            on { notify(any()) } doAnswer {}
-        }
-        val mockNotificationGroup = mock<NotificationGroup> {
-            on { createNotification( any(), anyOrNull(), any(), any<NotificationType>(), anyOrNull())} doReturn(mockNotification)
-        }
         val mockSdk = mock<Sdk> {
             on { name } doReturn ("test")
             on { homePath } doReturn (".")
         }
-        PyPackageSecurityScan.NOTIFICATION_GROUP = mockNotificationGroup
-        PyPackageSecurityScan.checkPackagesInSdks(setOf(mockSdk), project, instance)
-        verify(mockNotificationGroup, times(1)).createNotification( eq("Completed checking packages"), anyOrNull(), any(), eq(NotificationType.INFORMATION), anyOrNull())
-        verify(mockNotification, times(1)).notify(project)
+        assertEquals(PyPackageSecurityScan.checkPackagesInSdks(setOf(mockSdk), project, instance), 0)
     }
 
     @Test
     fun `test null packages`(){
-        val mockNotification = mock<Notification> {
-            on { notify(any()) } doAnswer {}
-        }
-        val mockNotificationGroup = mock<NotificationGroup> {
-            on { createNotification( any(), anyOrNull(), any(), any<NotificationType>(), anyOrNull())} doReturn(mockNotification)
-        }
         val mockPackageManager = mock<PyPackageManager> {
             on { packages } doReturn(null)
         }
-        PyPackageSecurityScan.NOTIFICATION_GROUP = mockNotificationGroup
-        PyPackageSecurityScan.inspectLocalPackages(mockPackageManager, project, instance)
-        verify(mockNotificationGroup, times(1)).createNotification( eq("Could not check Python packages"), anyOrNull(), any(), eq(NotificationType.INFORMATION), anyOrNull())
-        verify(mockNotification, times(1)).notify(project)
+        assertNull(PyPackageSecurityScan.inspectLocalPackages(mockPackageManager, project, instance))
     }
 
     @Test
     fun `test no packages`(){
-        val mockNotification = mock<Notification> {
-            on { notify(any()) } doAnswer {}
-        }
-        val mockNotificationGroup = mock<NotificationGroup> {
-            on { createNotification( any(), anyOrNull(), any(), any<NotificationType>(), anyOrNull())} doReturn(mockNotification)
-        }
         val mockPackageManager = mock<PyPackageManager> {
             on { packages } doReturn(listOf())
         }
-        PyPackageSecurityScan.NOTIFICATION_GROUP = mockNotificationGroup
-        PyPackageSecurityScan.inspectLocalPackages(mockPackageManager, project, instance)
-        verify(mockNotificationGroup, times(1)).createNotification( eq("Completed checking packages"), anyOrNull(), any(), eq(NotificationType.INFORMATION), anyOrNull())
-        verify(mockNotification, times(1)).notify(project)
+        assertEquals(PyPackageSecurityScan.inspectLocalPackages(mockPackageManager, project, instance), 0)
     }
 
     @Test
     fun `test ok packages`(){
-        val mockNotification = mock<Notification> {
-            on { notify(any()) } doAnswer {}
-        }
-        val mockNotificationGroup = mock<NotificationGroup> {
-            on { createNotification( any(), anyOrNull(), any(), any<NotificationType>(), anyOrNull())} doReturn(mockNotification)
-        }
         val testPackage1 = mock<PyPackage> {
             on { name } doReturn "good"
             on { version } doReturn "0.4.0"
@@ -148,23 +106,13 @@ class PyPackageSecurityScanTest: SecurityTestTask() {
         val mockPackageManager = mock<PyPackageManager> {
             on { packages } doReturn(listOf(testPackage1))
         }
-        PyPackageSecurityScan.NOTIFICATION_GROUP = mockNotificationGroup
-        PyPackageSecurityScan.inspectLocalPackages(mockPackageManager, project, instance)
-        verify(mockNotificationGroup, times(1)).createNotification( eq("Completed checking packages"), anyOrNull(), any(), eq(NotificationType.INFORMATION), anyOrNull())
-        verify(mockNotification, times(1)).notify(project)
+        assertEquals(PyPackageSecurityScan.inspectLocalPackages(mockPackageManager, project, instance), 0)
         verify(testPackage1, times(1)).name
         verify(mockPackageManager, times(2)).packages
     }
 
     @Test
     fun `test bad packages`(){
-        val mockNotification = mock<Notification> {
-            on { notify(any()) } doAnswer {}
-        }
-        val mockNotificationGroup = mock<NotificationGroup> {
-            on { createNotification( any(), anyOrNull(), any(), any<NotificationType>(), anyOrNull())} doReturn(mockNotification)
-            on { createNotification( any(), anyOrNull(), any(), any(), any())} doReturn(mockNotification)
-        }
         val testPackage1 = mock<PyPackage> {
             on { name } doReturn "apples"
             on { toString() } doReturn "apples"
@@ -178,12 +126,7 @@ class PyPackageSecurityScanTest: SecurityTestTask() {
         val mockPackageManager = mock<PyPackageManager> {
             on { packages } doReturn(listOf(testPackage1, testPackage2))
         }
-        PyPackageSecurityScan.NOTIFICATION_GROUP = mockNotificationGroup
-        PyPackageSecurityScan.inspectLocalPackages(mockPackageManager, project, instance)
-        verify(mockNotificationGroup, times(1)).createNotification( eq("Completed checking packages"), anyOrNull(), any(), eq(NotificationType.WARNING), anyOrNull())
-        verify(mockNotificationGroup, times(1)).createNotification( eq("Found Security Vulnerability in apples package"), anyOrNull(), any(), eq(NotificationType.WARNING), any())
-        verify(mockNotificationGroup, times(1)).createNotification( eq("Found Security Vulnerability in bananas package"), anyOrNull(), any(), eq(NotificationType.WARNING), any())
-        verify(mockNotification, times(3)).notify(project)
+        assertEquals(PyPackageSecurityScan.inspectLocalPackages(mockPackageManager, project, instance), 2)
         verify(testPackage1, times(2)).name
         verify(mockPackageManager, times(2)).packages
     }

--- a/src/test/java/security/packaging/PyPackageSecurityScanTest.kt
+++ b/src/test/java/security/packaging/PyPackageSecurityScanTest.kt
@@ -73,11 +73,11 @@ class PyPackageSecurityScanTest: SecurityTestTask() {
             on { notify(any()) } doAnswer {}
         }
         val mockNotificationGroup = mock<NotificationGroup> {
-            on { createNotification( any(), anyOrNull(), any(), any<NotificationType>())} doReturn(mockNotification)
+            on { createNotification( any(), anyOrNull(), any(), any<NotificationType>(), anyOrNull())} doReturn(mockNotification)
         }
         PyPackageSecurityScan.NOTIFICATION_GROUP = mockNotificationGroup
         PyPackageSecurityScan.checkPackages(project)
-        verify(mockNotificationGroup, times(1)).createNotification( eq("Could not check Python packages"), anyOrNull(), any(), eq(NotificationType.INFORMATION))
+        verify(mockNotificationGroup, times(1)).createNotification( eq("Could not check Python packages"), anyOrNull(), any(), eq(NotificationType.INFORMATION), anyOrNull())
         verify(mockNotification, times(1)).notify(project)
     }
 
@@ -87,7 +87,7 @@ class PyPackageSecurityScanTest: SecurityTestTask() {
             on { notify(any()) } doAnswer {}
         }
         val mockNotificationGroup = mock<NotificationGroup> {
-            on { createNotification( any(), anyOrNull(), any(), any<NotificationType>())} doReturn(mockNotification)
+            on { createNotification( any(), anyOrNull(), any(), any<NotificationType>(), anyOrNull())} doReturn(mockNotification)
         }
         val mockSdk = mock<Sdk> {
             on { name } doReturn ("test")
@@ -95,7 +95,7 @@ class PyPackageSecurityScanTest: SecurityTestTask() {
         }
         PyPackageSecurityScan.NOTIFICATION_GROUP = mockNotificationGroup
         PyPackageSecurityScan.checkPackagesInSdks(setOf(mockSdk), project, instance)
-        verify(mockNotificationGroup, times(1)).createNotification( eq("Completed checking packages"), anyOrNull(), any(), eq(NotificationType.INFORMATION))
+        verify(mockNotificationGroup, times(1)).createNotification( eq("Completed checking packages"), anyOrNull(), any(), eq(NotificationType.INFORMATION), anyOrNull())
         verify(mockNotification, times(1)).notify(project)
     }
 
@@ -105,14 +105,14 @@ class PyPackageSecurityScanTest: SecurityTestTask() {
             on { notify(any()) } doAnswer {}
         }
         val mockNotificationGroup = mock<NotificationGroup> {
-            on { createNotification( any(), anyOrNull(), any(), any<NotificationType>())} doReturn(mockNotification)
+            on { createNotification( any(), anyOrNull(), any(), any<NotificationType>(), anyOrNull())} doReturn(mockNotification)
         }
         val mockPackageManager = mock<PyPackageManager> {
             on { packages } doReturn(null)
         }
         PyPackageSecurityScan.NOTIFICATION_GROUP = mockNotificationGroup
         PyPackageSecurityScan.inspectLocalPackages(mockPackageManager, project, instance)
-        verify(mockNotificationGroup, times(1)).createNotification( eq("Could not check Python packages"), anyOrNull(), any(), eq(NotificationType.INFORMATION))
+        verify(mockNotificationGroup, times(1)).createNotification( eq("Could not check Python packages"), anyOrNull(), any(), eq(NotificationType.INFORMATION), anyOrNull())
         verify(mockNotification, times(1)).notify(project)
     }
 
@@ -122,14 +122,14 @@ class PyPackageSecurityScanTest: SecurityTestTask() {
             on { notify(any()) } doAnswer {}
         }
         val mockNotificationGroup = mock<NotificationGroup> {
-            on { createNotification( any(), anyOrNull(), any(), any<NotificationType>())} doReturn(mockNotification)
+            on { createNotification( any(), anyOrNull(), any(), any<NotificationType>(), anyOrNull())} doReturn(mockNotification)
         }
         val mockPackageManager = mock<PyPackageManager> {
             on { packages } doReturn(listOf())
         }
         PyPackageSecurityScan.NOTIFICATION_GROUP = mockNotificationGroup
         PyPackageSecurityScan.inspectLocalPackages(mockPackageManager, project, instance)
-        verify(mockNotificationGroup, times(1)).createNotification( eq("Completed checking packages"), anyOrNull(), any(), eq(NotificationType.INFORMATION))
+        verify(mockNotificationGroup, times(1)).createNotification( eq("Completed checking packages"), anyOrNull(), any(), eq(NotificationType.INFORMATION), anyOrNull())
         verify(mockNotification, times(1)).notify(project)
     }
 
@@ -139,7 +139,7 @@ class PyPackageSecurityScanTest: SecurityTestTask() {
             on { notify(any()) } doAnswer {}
         }
         val mockNotificationGroup = mock<NotificationGroup> {
-            on { createNotification( any(), anyOrNull(), any(), any<NotificationType>())} doReturn(mockNotification)
+            on { createNotification( any(), anyOrNull(), any(), any<NotificationType>(), anyOrNull())} doReturn(mockNotification)
         }
         val testPackage1 = mock<PyPackage> {
             on { name } doReturn "good"
@@ -150,7 +150,7 @@ class PyPackageSecurityScanTest: SecurityTestTask() {
         }
         PyPackageSecurityScan.NOTIFICATION_GROUP = mockNotificationGroup
         PyPackageSecurityScan.inspectLocalPackages(mockPackageManager, project, instance)
-        verify(mockNotificationGroup, times(1)).createNotification( eq("Completed checking packages"), anyOrNull(), any(), eq(NotificationType.INFORMATION))
+        verify(mockNotificationGroup, times(1)).createNotification( eq("Completed checking packages"), anyOrNull(), any(), eq(NotificationType.INFORMATION), anyOrNull())
         verify(mockNotification, times(1)).notify(project)
         verify(testPackage1, times(1)).name
         verify(mockPackageManager, times(2)).packages
@@ -162,7 +162,7 @@ class PyPackageSecurityScanTest: SecurityTestTask() {
             on { notify(any()) } doAnswer {}
         }
         val mockNotificationGroup = mock<NotificationGroup> {
-            on { createNotification( any(), anyOrNull(), any(), any<NotificationType>())} doReturn(mockNotification)
+            on { createNotification( any(), anyOrNull(), any(), any<NotificationType>(), anyOrNull())} doReturn(mockNotification)
             on { createNotification( any(), anyOrNull(), any(), any(), any())} doReturn(mockNotification)
         }
         val testPackage1 = mock<PyPackage> {
@@ -180,7 +180,7 @@ class PyPackageSecurityScanTest: SecurityTestTask() {
         }
         PyPackageSecurityScan.NOTIFICATION_GROUP = mockNotificationGroup
         PyPackageSecurityScan.inspectLocalPackages(mockPackageManager, project, instance)
-        verify(mockNotificationGroup, times(1)).createNotification( eq("Completed checking packages"), anyOrNull(), any(), eq(NotificationType.WARNING))
+        verify(mockNotificationGroup, times(1)).createNotification( eq("Completed checking packages"), anyOrNull(), any(), eq(NotificationType.WARNING), anyOrNull())
         verify(mockNotificationGroup, times(1)).createNotification( eq("Found Security Vulnerability in apples package"), anyOrNull(), any(), eq(NotificationType.WARNING), any())
         verify(mockNotificationGroup, times(1)).createNotification( eq("Found Security Vulnerability in bananas package"), anyOrNull(), any(), eq(NotificationType.WARNING), any())
         verify(mockNotification, times(3)).notify(project)


### PR DESCRIPTION
The new version of PyCharm is coming, so test the APIs and compatibility against both versions to ensure the package can be maintained across versions