### PR TITLE
Fix fixers for Mako and Jinja2

### DIFF
--- a/src/main/java/security/fixes/FixUtil.kt
+++ b/src/main/java/security/fixes/FixUtil.kt
@@ -12,7 +12,7 @@ fun getPyExpressionAtCaret(file: PsiFile, editor: Editor): PyExpression? {
 }
 
 fun getPyCallExpressionAtCaret(file: PsiFile, editor: Editor): PyCallExpression? {
-    return PsiTreeUtil.getParentOfType(file.findElementAt(editor.caretModel.offset), PyCallExpression::class.java) ?: return null
+    return PsiTreeUtil.getTopmostParentOfType(file.findElementAt(editor.caretModel.offset), PyCallExpression::class.java) ?: return null
 }
 
 fun getListLiteralExpressionAtCaret(file: PsiFile, editor: Editor): PyListLiteralExpression? {
@@ -50,5 +50,14 @@ fun importFrom(file: PyFile, project: Project, target: String, component: String
             file.addAfter(newImportFrom, lastImport)
     } else {
         file.addBefore(newImportFrom, file.statements.first())
+    }
+}
+
+fun addKeywordArgument(pyCallExpression: PyCallExpression, pyKeywordArgument: PyKeywordArgument) {
+    val lastArgument = pyCallExpression.arguments.lastOrNull()
+    if (lastArgument == null) {
+        pyCallExpression.argumentList?.addArgument(pyKeywordArgument)
+    } else {
+        pyCallExpression.argumentList?.addArgumentAfter(pyKeywordArgument, lastArgument)
     }
 }

--- a/src/main/java/security/fixes/JinjaAutoinspectFixer.kt
+++ b/src/main/java/security/fixes/JinjaAutoinspectFixer.kt
@@ -43,9 +43,8 @@ class JinjaAutoinspectUnconditionalFixer : LocalQuickFix, IntentionAction, HighP
         val autoescapeArgument = newEl.getKeywordArgument("autoescape")
         val elementGenerator = PyElementGenerator.getInstance(project)
         val newArg = elementGenerator.createKeywordArgument(file.languageLevel, "autoescape", "True")
-        if (autoescapeArgument == null)
-        {
-            newEl.argumentList?.addArgument(newArg)
+        if (autoescapeArgument == null) {
+            addKeywordArgument(newEl, newArg)
         } else {
             if (autoescapeArgument is PyCallExpression) return null
             if (autoescapeArgument !is PyBoolLiteralExpression) return null

--- a/src/main/java/security/fixes/MakoFilterFixer.kt
+++ b/src/main/java/security/fixes/MakoFilterFixer.kt
@@ -44,7 +44,7 @@ class MakoFilterFixer: LocalQuickFix, IntentionAction, HighPriorityAction {
         if (autoescapeArgument != null) return null
         val elementGenerator = PyElementGenerator.getInstance(project)
         val newArg = elementGenerator.createKeywordArgument(file.languageLevel, "default_filters", "['h']")
-        newEl.argumentList?.addArgument(newArg)
+        addKeywordArgument(newEl, newArg)
         originalElement.replace(newEl)
         return newEl
     }

--- a/src/test/java/security/fixes/MakoFilterFixerTest.kt
+++ b/src/test/java/security/fixes/MakoFilterFixerTest.kt
@@ -63,6 +63,16 @@ class MakoFilterFixerTest: SecurityTestTask() {
     }
 
     @Test
+    fun `replace environment with nested keyword args`(){
+        var code = """
+            import mako.template
+            env = mako.template.Template(str(value='xyz'))
+        """.trimIndent()
+        val newCode = getNewFileForCode(code)
+        TestCase.assertEquals("mako.template.Template(str(value='xyz'),default_filters=['h'])", newCode)
+    }
+
+    @Test
     fun `replace environment with existing arg`(){
         var code = """
             import mako.template


### PR DESCRIPTION
This PR fixes fixers for Mako and Jinja2.

I found two problems. The PR fixes the problems.

1.  `newEl.argumentList?.addArgument(newArg)`  adds `newArg` to last of all arguments which include arguments of childs.

2. `PsiTreeUtil.getParentOfType` get near parent object. If the user clicks nested object then, the method does not return the topmost object. 

## Related issues
https://github.com/tonybaloney/pycharm-security/issues/118